### PR TITLE
Fix GHSA-5p4m-2wfm-xmqj: upgrade js-yaml to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3479,9 +3479,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3928,9 +3928,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Upgrades transitive `js-yaml` from 3.15.0 to 3.15.1 to fix [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) (quadratic CPU consumption in `!!omap` resolution)
- Also bumps `nanoid` 3.3.16 → 3.3.18 via `npm audit fix` (fixes GHSA-2v37-7h3g-55p8)

## Context
`js-yaml` is pulled in transitively by Jest via `@istanbuljs/load-nyc-config`. The vulnerable version could allow denial-of-service when parsing untrusted YAML with large `!!omap` sequences.

## Test plan
- [x] `npm install`
- [x] `npm audit` reports 0 vulnerabilities
- [x] Verified dependency tree: `jest → @istanbuljs/load-nyc-config → js-yaml@3.15.1`


Made with [Cursor](https://cursor.com)